### PR TITLE
Frame corners clipped content at smaller sizes.

### DIFF
--- a/SvgXF/SvgXF/Icon.cs
+++ b/SvgXF/SvgXF/Icon.cs
@@ -39,6 +39,7 @@ namespace SvgXF
             Padding = new Thickness(0);
             BackgroundColor = Color.Transparent;
             HasShadow = false;
+            CornerRadius = 0.0f;
             Content = _canvasView;
             _canvasView.PaintSurface += CanvasViewOnPaintSurface;
         }


### PR DESCRIPTION
Setting the CornerRadius to 0 allows the entire SVG to be viewed with no margin, padding, or clipping.

To reproduce the issue, create a solid square in an SVG file and display it at a desired width of 16.